### PR TITLE
[FEAT] Custom Domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,6 @@ website/node_modules
 *.iml
 .env
 
-# Build file
-terraform-provider-propelauth
-
 website/vendor
 
 # Test exclusions
@@ -37,3 +34,6 @@ website/vendor
 
 # Keep windows files with windows line endings
 *.winfile eol=crlf
+
+# Build file
+terraform-provider-propelauth

--- a/examples/resources/custom_domain/main.tf
+++ b/examples/resources/custom_domain/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    propelauth = {
+      source = "registry.terraform.io/propelauth/propelauth"
+    }
+  }
+}
+
+provider "propelauth" {
+  # tenant_id  = "<PROPELAUTH_TENANT_ID>"  # or PROPELAUTH_TENANT_ID environment variable
+  # project_id = "<PROPELAUTH_PROJECT_ID>" # or PROPELAUTH_PROJECT_ID environment variable
+  # api_key    = "<PROPELAUTH_API_KEY>"    # or PROPELAUTH_API_KEY environment variable
+}
+
+resource "propelauth_custom_domain" "my_custom_domain" {
+  environment = "Staging"
+  domain      = "example.com"
+  # subdomain   = "app" # Optional
+}
+
+output "project_custom_domain_result" {
+  value = propelauth_custom_domain.my_custom_domain
+}

--- a/examples/resources/custom_domain/main.tf
+++ b/examples/resources/custom_domain/main.tf
@@ -17,7 +17,7 @@ provider "propelauth" {
 }
 
 resource "propelauth_custom_domain" "my_custom_domain" {
-  environment = "Prod"
+  environment = "Staging"
   domain      = "sharpenchess.com"
   # subdomain   = "app" # Optional
 }
@@ -38,9 +38,9 @@ resource "propelauth_custom_domain" "my_custom_domain" {
 # }
 
 resource "propelauth_custom_domain_verification" "my_custom_domain_verification" {
-  # depends_on = [
-  #   propelauth_custom_domain.my_custom_domain,
-  # ]
+  depends_on = [
+    propelauth_custom_domain.my_custom_domain,
+  ]
   environment = propelauth_custom_domain.my_custom_domain.environment
   domain      = propelauth_custom_domain.my_custom_domain.domain
   # timeouts { create = "15m" }

--- a/examples/resources/custom_domain/main.tf
+++ b/examples/resources/custom_domain/main.tf
@@ -3,6 +3,10 @@ terraform {
     propelauth = {
       source = "registry.terraform.io/propelauth/propelauth"
     }
+    # aws = {
+    #   source  = "hashicorp/aws"
+    #   version = "~> 5.0"
+    # }
   }
 }
 
@@ -14,8 +18,31 @@ provider "propelauth" {
 
 resource "propelauth_custom_domain" "my_custom_domain" {
   environment = "Staging"
-  domain      = "example.com"
+  domain      = "itailevi.com"
   # subdomain   = "app" # Optional
+}
+
+# resource "aws_route53_record" "txt_record_for_propelauth" {
+#   zone_id = aws_route53_zone.primary.zone_id
+#   name    = propelauth_custom_domain.my_custom_domain.txt_record_key
+#   type    = "TXT"
+#   ttl     = 300
+#   records = [propelauth_custom_domin.my_custom_domain.txt_record_value]
+# }
+
+# resource "aws_route53_record" "cname_record_for_propelauth" {
+#   zone_id = aws_route53_zone.primary.zone_id
+#   name    = propelauth_custom_domain.my_custom_domain.cname_record_key
+#   type    = "CNAME"
+#   records = [propelauth_custom_domin.my_custom_domain.cname_record_value]
+# }
+
+resource "propelauth_custom_domain_verification" "my_custom_domain_verification" {
+  depends_on = [
+    propelauth_custom_domain.my_custom_domain,
+  ]
+  environment = propelauth_custom_domain.my_custom_domain.environment
+  # timeouts { create = "15m" }
 }
 
 output "project_custom_domain_result" {

--- a/examples/resources/custom_domain/main.tf
+++ b/examples/resources/custom_domain/main.tf
@@ -11,35 +11,37 @@ terraform {
 }
 
 provider "propelauth" {
-  # tenant_id  = "<PROPELAUTH_TENANT_ID>"  # or PROPELAUTH_TENANT_ID environment variable
-  # project_id = "<PROPELAUTH_PROJECT_ID>" # or PROPELAUTH_PROJECT_ID environment variable
-  # api_key    = "<PROPELAUTH_API_KEY>"    # or PROPELAUTH_API_KEY environment variable
+  tenant_id  = "<PROPELAUTH_TENANT_ID>"  # or PROPELAUTH_TENANT_ID environment variable
+  project_id = "<PROPELAUTH_PROJECT_ID>" # or PROPELAUTH_PROJECT_ID environment variable
+  api_key    = "<PROPELAUTH_API_KEY>"    # or PROPELAUTH_API_KEY environment variable
 }
 
+# This resource just sets up the process of verifying the domain. 
+# It will return the TXT and CNAME records that you need to add to your DNS settings.
+# You will need to add these records to your DNS settings manually or using Terraform.
+# Then, the "propelauth_custom_domain_verification" resource will verify the domain.
 resource "propelauth_custom_domain" "my_custom_domain" {
-  environment = "Prod"
+  # The environment can either be "Prod" or "Staging"
+  environment = "Prod" 
+
+  # The domain to use. Your auth domain will be `auth.<domain>`. 
+  # You can also specify a subdomain like prod.example.com which will result in auth.prod.example.com
   domain      = "example.com"
-  # subdomain   = "app" # Optional
+
+  # The subdomain where your application is hosted. 
+  # This is optional, but recommended, as it will allow PropelAuth to automatically redirect users to your application after they login.
+  # subdomain   = "app"
 }
 
-# resource "aws_route53_record" "txt_record_for_propelauth" {
-#   zone_id = aws_route53_zone.primary.zone_id
-#   name    = propelauth_custom_domain.my_custom_domain.txt_record_key
-#   type    = "TXT"
-#   ttl     = 300
-#   records = [propelauth_custom_domin.my_custom_domain.txt_record_value]
-# }
-
-# resource "aws_route53_record" "cname_record_for_propelauth" {
-#   zone_id = aws_route53_zone.primary.zone_id
-#   name    = propelauth_custom_domain.my_custom_domain.cname_record_key
-#   type    = "CNAME"
-#   records = [propelauth_custom_domin.my_custom_domain.cname_record_value]
-# }
-
+# This resource will verify the domain. You must set up the DNS records first.
+# You can use the output of the "propelauth_custom_domain" resource to set up the DNS records.
 resource "propelauth_custom_domain_verification" "my_custom_domain_verification" {
   depends_on = [
     propelauth_custom_domain.my_custom_domain,
+
+    # See below for an example of using Route53 for the custom domain
+    aws_route53_record.txt_record_for_propelauth,
+    aws_route53_record.cname_record_for_propelauth
   ]
   environment = propelauth_custom_domain.my_custom_domain.environment
   domain      = propelauth_custom_domain.my_custom_domain.domain
@@ -47,4 +49,29 @@ resource "propelauth_custom_domain_verification" "my_custom_domain_verification"
 
 output "project_custom_domain_result" {
   value = propelauth_custom_domain.my_custom_domain
+}
+
+
+
+# AWS Route53 Example
+resource "aws_route53_zone" "primary" {
+  name = "example.com"
+}
+
+resource "aws_route53_record" "txt_record_for_propelauth" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = propelauth_custom_domain.my_custom_domain.txt_record_key
+  type    = "TXT"
+  ttl     = 300
+  records = [propelauth_custom_domain.my_custom_domain.txt_record_value]
+  depends_on = [propelauth_custom_domain.my_custom_domain]
+}
+
+resource "aws_route53_record" "cname_record_for_propelauth" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = propelauth_custom_domain.my_custom_domain.cname_record_key
+  type    = "CNAME"
+  ttl     = 300
+  records = [propelauth_custom_domain.my_custom_domain.cname_record_value]
+  depends_on = [propelauth_custom_domain.my_custom_domain]
 }

--- a/examples/resources/custom_domain/main.tf
+++ b/examples/resources/custom_domain/main.tf
@@ -17,8 +17,8 @@ provider "propelauth" {
 }
 
 resource "propelauth_custom_domain" "my_custom_domain" {
-  environment = "Staging"
-  domain      = "sharpenchess.com"
+  environment = "Prod"
+  domain      = "example.com"
   # subdomain   = "app" # Optional
 }
 
@@ -43,7 +43,6 @@ resource "propelauth_custom_domain_verification" "my_custom_domain_verification"
   ]
   environment = propelauth_custom_domain.my_custom_domain.environment
   domain      = propelauth_custom_domain.my_custom_domain.domain
-  # timeouts { create = "15m" }
 }
 
 output "project_custom_domain_result" {

--- a/examples/resources/custom_domain/main.tf
+++ b/examples/resources/custom_domain/main.tf
@@ -17,8 +17,8 @@ provider "propelauth" {
 }
 
 resource "propelauth_custom_domain" "my_custom_domain" {
-  environment = "Staging"
-  domain      = "itailevi.com"
+  environment = "Prod"
+  domain      = "sharpenchess.com"
   # subdomain   = "app" # Optional
 }
 
@@ -38,10 +38,11 @@ resource "propelauth_custom_domain" "my_custom_domain" {
 # }
 
 resource "propelauth_custom_domain_verification" "my_custom_domain_verification" {
-  depends_on = [
-    propelauth_custom_domain.my_custom_domain,
-  ]
+  # depends_on = [
+  #   propelauth_custom_domain.my_custom_domain,
+  # ]
   environment = propelauth_custom_domain.my_custom_domain.environment
+  domain      = propelauth_custom_domain.my_custom_domain.domain
   # timeouts { create = "15m" }
 }
 

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
+	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/hashicorp/terraform-plugin-docs v0.19.4 h1:G3Bgo7J22OMtegIgn8Cd/CaSey
 github.com/hashicorp/terraform-plugin-docs v0.19.4/go.mod h1:4pLASsatTmRynVzsjEhbXZ6s7xBlUw/2Kt0zfrq8HxA=
 github.com/hashicorp/terraform-plugin-framework v1.10.0 h1:xXhICE2Fns1RYZxEQebwkB2+kXouLC932Li9qelozrc=
 github.com/hashicorp/terraform-plugin-framework v1.10.0/go.mod h1:qBXLDn69kM97NNVi/MQ9qgd1uWWsVftGSnygYG1tImM=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1 h1:gm5b1kHgFFhaKFhm4h2TgvMUlNzFAtUqlcOWnWPm+9E=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1/go.mod h1:MsjL1sQ9L7wGwzJ5RjcI6FzEMdyoBnw+XK8ZnOvQOLY=
 github.com/hashicorp/terraform-plugin-framework-validators v0.13.0 h1:bxZfGo9DIUoLLtHMElsu+zwqI4IsMZQBRRy4iLzZJ8E=
 github.com/hashicorp/terraform-plugin-framework-validators v0.13.0/go.mod h1:wGeI02gEhj9nPANU62F2jCaHjXulejm/X+af4PdZaNo=
 github.com/hashicorp/terraform-plugin-go v0.23.0 h1:AALVuU1gD1kPb48aPQUjug9Ir/125t+AAurhqphJ2Co=

--- a/internal/propelauth/client.go
+++ b/internal/propelauth/client.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TODO: FOR THE LOVE OF GOD, DON'T FORGET TO CHANGE THIS TO THE REAL URL.
-const BaseURLTemplate string = "https://api.propelauth.localhost/iac/%s/project/%s"
+const BaseURLTemplate string = "https://api.propelauth.com/iac/%s/project/%s"
 
 // PropelAuthClient - Client for the PropelAuth API to manage an existing project and all its resources.
 type PropelAuthClient struct {

--- a/internal/propelauth/custom_domain.go
+++ b/internal/propelauth/custom_domain.go
@@ -1,0 +1,48 @@
+package propelauth
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GetCustomDomainInfo - Returns the custom domain info for the requested environment
+func (c *PropelAuthClient) GetCustomDomainInfo(environment string) (*CustomDomainInfo, error) {
+	res, err := c.get(fmt.Sprintf("custom_domain?environment=%v", environment), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	customDomainInfo := CustomDomainInfo{}
+	err = json.Unmarshal(res.BodyBytes, &customDomainInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return &customDomainInfo, nil
+}
+
+// UpdateCustomDomainInfo - Updates the custom domain info for the requested environment
+func (c *PropelAuthClient) UpdateCustomDomainInfo(environment string, domain string, subdomain *string) (*CustomDomainInfo, error) {
+	request := customDomainUpdateRequest{
+		Domain: domain,
+		Subdomain: subdomain,
+	}
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.put(fmt.Sprintf("%v/custom_domain", environment), body)
+	if err != nil {
+		return nil, err
+	}
+
+	customDomainInfo := CustomDomainInfo{}
+	err = json.Unmarshal(res.BodyBytes, &customDomainInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return &customDomainInfo, nil
+}

--- a/internal/propelauth/custom_domain.go
+++ b/internal/propelauth/custom_domain.go
@@ -6,8 +6,8 @@ import (
 )
 
 // GetCustomDomainInfo - Returns the custom domain info for the requested environment
-func (c *PropelAuthClient) GetCustomDomainInfo(environment string) (*CustomDomainInfo, error) {
-	res, err := c.get(fmt.Sprintf("custom_domain?environment=%v", environment), nil)
+func (c *PropelAuthClient) GetCustomDomainInfo(environment string, isSwitching bool) (*CustomDomainInfo, error) {
+	res, err := c.get(fmt.Sprintf("custom_domain?environment=%v&is_switching=%v", environment, isSwitching), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -22,11 +22,12 @@ func (c *PropelAuthClient) GetCustomDomainInfo(environment string) (*CustomDomai
 }
 
 // UpdateCustomDomainInfo - Updates the custom domain info for the requested environment
-func (c *PropelAuthClient) UpdateCustomDomainInfo(environment string, domain string, subdomain *string) (*CustomDomainInfo, error) {
+func (c *PropelAuthClient) UpdateCustomDomainInfo(environment string, domain string, subdomain *string, isSwitching bool) (*CustomDomainInfo, error) {
 	request := customDomainUpdateRequest{
 		Domain: domain,
 		Subdomain: subdomain,
 		Environment: environment,
+		IsSwitching: isSwitching,
 	}
 
 	body, err := json.Marshal(request)
@@ -49,9 +50,10 @@ func (c *PropelAuthClient) UpdateCustomDomainInfo(environment string, domain str
 }
 
 // VerifyCustomDomainInfo - Verifies the custom domain info for the requested environment
-func (c *PropelAuthClient) VerifyCustomDomainInfo(environment string) error {
+func (c *PropelAuthClient) VerifyCustomDomainInfo(environment string, isSwitching bool) error {
 	request := customDomainVerifyRequest{
 		Environment: environment,
+		IsSwitching: isSwitching,
 	}
 	body, err := json.Marshal(request)
 	if err != nil {

--- a/internal/propelauth/custom_domain.go
+++ b/internal/propelauth/custom_domain.go
@@ -6,13 +6,13 @@ import (
 )
 
 // GetCustomDomainInfo - Returns the custom domain info for the requested environment
-func (c *PropelAuthClient) GetCustomDomainInfo(environment string, isSwitching bool) (*CustomDomainInfo, error) {
+func (c *PropelAuthClient) GetCustomDomainInfo(environment string, isSwitching bool) (*CustomDomainInfoResponse, error) {
 	res, err := c.get(fmt.Sprintf("custom_domain?environment=%v&is_switching=%v", environment, isSwitching), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	customDomainInfo := CustomDomainInfo{}
+	customDomainInfo := CustomDomainInfoResponse{}
 	err = json.Unmarshal(res.BodyBytes, &customDomainInfo)
 	if err != nil {
 		return nil, err
@@ -22,7 +22,7 @@ func (c *PropelAuthClient) GetCustomDomainInfo(environment string, isSwitching b
 }
 
 // UpdateCustomDomainInfo - Updates the custom domain info for the requested environment
-func (c *PropelAuthClient) UpdateCustomDomainInfo(environment string, domain string, subdomain *string, isSwitching bool) (*CustomDomainInfo, error) {
+func (c *PropelAuthClient) UpdateCustomDomainInfo(environment string, domain string, subdomain *string, isSwitching bool) (*CustomDomainInfoResponse, error) {
 	request := customDomainUpdateRequest{
 		Domain: domain,
 		Subdomain: subdomain,
@@ -40,7 +40,7 @@ func (c *PropelAuthClient) UpdateCustomDomainInfo(environment string, domain str
 		return nil, err
 	}
 
-	customDomainInfo := CustomDomainInfo{}
+	customDomainInfo := CustomDomainInfoResponse{}
 	err = json.Unmarshal(res.BodyBytes, &customDomainInfo)
 	if err != nil {
 		return nil, err

--- a/internal/propelauth/custom_domain.go
+++ b/internal/propelauth/custom_domain.go
@@ -47,3 +47,20 @@ func (c *PropelAuthClient) UpdateCustomDomainInfo(environment string, domain str
 
 	return &customDomainInfo, nil
 }
+
+// VerifyCustomDomainInfo - Verifies the custom domain info for the requested environment
+func (c *PropelAuthClient) VerifyCustomDomainInfo(environment string) error {
+	request := customDomainVerifyRequest{
+		Environment: environment,
+	}
+	body, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.post("custom_domain/verify", body)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/propelauth/custom_domain.go
+++ b/internal/propelauth/custom_domain.go
@@ -26,6 +26,7 @@ func (c *PropelAuthClient) UpdateCustomDomainInfo(environment string, domain str
 	request := customDomainUpdateRequest{
 		Domain: domain,
 		Subdomain: subdomain,
+		Environment: environment,
 	}
 
 	body, err := json.Marshal(request)
@@ -33,7 +34,7 @@ func (c *PropelAuthClient) UpdateCustomDomainInfo(environment string, domain str
 		return nil, err
 	}
 
-	res, err := c.put(fmt.Sprintf("%v/custom_domain", environment), body)
+	res, err := c.put("custom_domain", body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/propelauth/models.go
+++ b/internal/propelauth/models.go
@@ -252,11 +252,11 @@ type BeApiKey struct {
 
 type CustomDomainInfo struct {
 	Domain string `json:"domain"`
-	Subdomain string `json:"subdomain"`
+	Subdomain *string `json:"subdomain"`
 	IsVerified bool `json:"is_verified"`
 	IsPending bool `json:"is_pending"`
 	TxtRecordKey string `json:"txt_record_key"`
-	TxtRecord string `json:"txt_record"`
+	TxtRecordValue string `json:"txt_record_value"`
 	CnameRecordKey string `json:"cname_record_key"`
 	CnameRecordValue string `json:"cname_record_value"`
 }
@@ -264,4 +264,5 @@ type CustomDomainInfo struct {
 type customDomainUpdateRequest struct {
 	Domain string `json:"domain"`
 	Subdomain *string `json:"subdomain,omitempty"`
+	Environment string `json:"environment"`
 }

--- a/internal/propelauth/models.go
+++ b/internal/propelauth/models.go
@@ -254,18 +254,21 @@ type CustomDomainInfo struct {
 	Domain string `json:"domain"`
 	Subdomain *string `json:"subdomain"`
 	IsVerified bool `json:"is_verified"`
-	TxtRecordKey string `json:"txt_record_key"`
-	TxtRecordValue string `json:"txt_record_value"`
-	CnameRecordKey string `json:"cname_record_key"`
-	CnameRecordValue string `json:"cname_record_value"`
+	IsPending bool `json:"is_pending"`
+	TxtRecordKey *string `json:"txt_record_key"`
+	TxtRecordValue *string `json:"txt_record_value"`
+	CnameRecordKey *string `json:"cname_record_key"`
+	CnameRecordValue *string `json:"cname_record_value"`
 }
 
 type customDomainUpdateRequest struct {
 	Domain string `json:"domain"`
 	Subdomain *string `json:"subdomain,omitempty"`
 	Environment string `json:"environment"`
+	IsSwitching bool `json:"is_switching"`
 }
 
 type customDomainVerifyRequest struct {
 	Environment string `json:"environment"`
+	IsSwitching bool `json:"is_switching"`
 }

--- a/internal/propelauth/models.go
+++ b/internal/propelauth/models.go
@@ -250,7 +250,7 @@ type BeApiKey struct {
 	IsReadOnly bool   `json:"readonly"`
 }
 
-type CustomDomainInfo struct {
+type CustomDomainInfoResponse struct {
 	Domain string `json:"domain"`
 	Subdomain *string `json:"subdomain"`
 	IsVerified bool `json:"is_verified"`

--- a/internal/propelauth/models.go
+++ b/internal/propelauth/models.go
@@ -249,3 +249,19 @@ type BeApiKey struct {
 	Name       string `json:"name"`
 	IsReadOnly bool   `json:"readonly"`
 }
+
+type CustomDomainInfo struct {
+	Domain string `json:"domain"`
+	Subdomain string `json:"subdomain"`
+	IsVerified bool `json:"is_verified"`
+	IsPending bool `json:"is_pending"`
+	TxtRecordKey string `json:"txt_record_key"`
+	TxtRecord string `json:"txt_record"`
+	CnameRecordKey string `json:"cname_record_key"`
+	CnameRecordValue string `json:"cname_record_value"`
+}
+
+type customDomainUpdateRequest struct {
+	Domain string `json:"domain"`
+	Subdomain *string `json:"subdomain,omitempty"`
+}

--- a/internal/propelauth/models.go
+++ b/internal/propelauth/models.go
@@ -254,7 +254,6 @@ type CustomDomainInfo struct {
 	Domain string `json:"domain"`
 	Subdomain *string `json:"subdomain"`
 	IsVerified bool `json:"is_verified"`
-	IsPending bool `json:"is_pending"`
 	TxtRecordKey string `json:"txt_record_key"`
 	TxtRecordValue string `json:"txt_record_value"`
 	CnameRecordKey string `json:"cname_record_key"`
@@ -264,5 +263,9 @@ type CustomDomainInfo struct {
 type customDomainUpdateRequest struct {
 	Domain string `json:"domain"`
 	Subdomain *string `json:"subdomain,omitempty"`
+	Environment string `json:"environment"`
+}
+
+type customDomainVerifyRequest struct {
 	Environment string `json:"environment"`
 }

--- a/internal/provider/custom_domain_resource.go
+++ b/internal/provider/custom_domain_resource.go
@@ -1,0 +1,161 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"terraform-provider-propelauth/internal/propelauth"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &customDomainResource{}
+var _ resource.ResourceWithConfigure   = &customDomainResource{}
+
+func NewCustomDomainResource() resource.Resource {
+	return &customDomainResource{}
+}
+
+// customDomainResource defines the resource implementation.
+type customDomainResource struct {
+	client *propelauth.PropelAuthClient
+}
+
+// projectInfoResourceModel describes the resource data model.
+type customDomainResourceModel struct {
+	Environment types.String `tfsdk:"environment"`
+	Domain types.String `tfsdk:"domain"`
+	Subdomain types.String `tfsdk:"subdomain"`
+}
+
+func (r *customDomainResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_custom_domain"
+}
+
+func (r *customDomainResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		Description: "Custom Domain resource. This is for configuring a custom domain for Production or Staging.",
+		Attributes: map[string]schema.Attribute{
+			"environment": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("Staging", "Prod", "PendingStaging", "PendingProd"),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "The environment for which you are configuring the custom domain. Accepted values are `Staging`, `Prod`, `PendingStaging`, and `PendingProd`. Use the `Pending` environments for switching.",
+			},
+			"domain": schema.StringAttribute{
+				Required: true,
+				Description: "The domain name for the custom domain.",
+			},
+			"subdomain": schema.StringAttribute{
+				Optional: true,
+				Description: "The subdomain for the custom domain. This is optional.",
+			},
+		},
+	}
+}
+
+func (r *customDomainResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*propelauth.PropelAuthClient)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *propelauth.PropelAuthClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *customDomainResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan customDomainResourceModel
+
+	// Read Terraform plan data into the model
+	diags := req.Plan.Get(ctx, &plan)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+	// Update the custom domain info
+	environment := plan.Environment.ValueString()
+	domain := plan.Domain.ValueString()
+	subdomain := plan.Subdomain.ValueString()
+	customDomainInfo, err := r.client.UpdateCustomDomainInfo(environment, domain, &subdomain)
+    if err != nil {
+        resp.Diagnostics.AddError(
+			"Error setting custom domain info",
+			"Could not set custom domain info, unexpected error: " + err.Error(),
+		)
+        return
+    }
+
+
+	// save into the Terraform state.
+	plan.Domain = types.StringValue(customDomainInfo.Domain)
+	plan.Subdomain = types.StringValue(customDomainInfo.Subdomain)
+
+	// Write logs using the tflog package
+	// Documentation: https://terraform.io/plugin/log
+	tflog.Trace(ctx, "created a propelauth_project_info resource")
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *customDomainResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Read the data from the state
+	var state customDomainResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get the custom domain info
+	environment := state.Environment.ValueString()
+	customDomainInfo, err := r.client.GetCustomDomainInfo(environment)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error getting custom domain info",
+			"Could not get custom domain info, unexpected error: " + err.Error(),
+		)
+		return
+	}
+
+	// Write logs using the tflog package
+	// Documentation: https://terraform.io/plugin/log
+	tflog.Trace(ctx, "read a custom_domain resource")
+
+	// Set the data from the state into the response
+	state.Domain = types.StringValue(customDomainInfo.Domain)
+	state.Subdomain = types.StringValue(customDomainInfo.Subdomain)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *customDomainResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// TODO
+}
+
+func (r *customDomainResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	tflog.Trace(ctx, "deleted a custom_domain resource")
+}

--- a/internal/provider/custom_domain_resource.go
+++ b/internal/provider/custom_domain_resource.go
@@ -168,7 +168,7 @@ func (r *customDomainResource) Read(ctx context.Context, req resource.ReadReques
 
 	isSwitching := isDomainOrSubdomainChanged && customDomainInfo.IsVerified
 	if isSwitching {
-		// If the domain is switching, we need to fetch the pending state instead.
+		// If the domain is switching, fetch the pending state instead.
 		customDomainInfo, err = r.client.GetCustomDomainInfo(environment, true)
 		if err != nil {
 			resp.Diagnostics.AddError(
@@ -187,6 +187,9 @@ func (r *customDomainResource) Read(ctx context.Context, req resource.ReadReques
 	state.Domain = types.StringValue(customDomainInfo.Domain)
 	state.Subdomain = types.StringPointerValue(customDomainInfo.Subdomain)
 
+	// So as not to need an update after verification of a domain, 
+	// these fields are only updated if the domain is not verified, which is when they are
+	// returned.
 	if customDomainInfo.TxtRecordKey != nil {
 		state.TxtRecordKey = types.StringPointerValue(customDomainInfo.TxtRecordKey)
 	}

--- a/internal/provider/custom_domain_resource.go
+++ b/internal/provider/custom_domain_resource.go
@@ -142,7 +142,7 @@ func (r *customDomainResource) Create(ctx context.Context, req resource.CreateRe
 
 	// Write logs using the tflog package
 	// Documentation: https://terraform.io/plugin/log
-	tflog.Trace(ctx, "created a propelauth_project_info resource")
+	tflog.Trace(ctx, "created a propelauth_custom_domain resource")
 
 	// Derive fields so they can be used either with or without the full domain
 	cnameRecordKeyParts := strings.Split(*customDomainInfo.CnameRecordKey, ".")
@@ -278,7 +278,7 @@ func (r *customDomainResource) Update(ctx context.Context, req resource.UpdateRe
 
 	// Write logs using the tflog package
 	// Documentation: https://terraform.io/plugin/log
-	tflog.Trace(ctx, "updated a custom_domain resource")
+	tflog.Trace(ctx, "updated a propelauth_custom_domain resource")
 
 	// Derive fields so they can be used either with or without the full domain
 	cnameRecordKeyParts := strings.Split(*customDomainInfo.CnameRecordKey, ".")
@@ -298,5 +298,5 @@ func (r *customDomainResource) Update(ctx context.Context, req resource.UpdateRe
 }
 
 func (r *customDomainResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	tflog.Trace(ctx, "deleted a custom_domain resource")
+	tflog.Trace(ctx, "deleted a propelauth_custom_domain resource")
 }

--- a/internal/provider/custom_domain_resource_test.go
+++ b/internal/provider/custom_domain_resource_test.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccCustomDomainResource(t *testing.T) {
+	subdomain := "app"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccCustomDomainResourceConfig("example.com", nil, "Prod"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("propelauth_custom_domain.test", "environment", "Prod"),
+					resource.TestCheckResourceAttr("propelauth_custom_domain.test", "domain", "example.com"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "txt_record_key"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "txt_record_value"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "cname_record_key"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "cname_record_value"),
+					resource.TestCheckNoResourceAttr("propelauth_custom_domain.test", "subdomain"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: testAccCustomDomainResourceConfig("example2.com", nil, "Prod"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("propelauth_custom_domain.test", "environment", "Prod"),
+					resource.TestCheckResourceAttr("propelauth_custom_domain.test", "domain", "example2.com"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "txt_record_key"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "txt_record_value"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "cname_record_key"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "cname_record_value"),
+					resource.TestCheckNoResourceAttr("propelauth_custom_domain.test", "subdomain"),
+				),
+			},
+			{
+				Config: testAccCustomDomainResourceConfig("example.com", &subdomain, "Prod"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("propelauth_custom_domain.test", "environment", "Prod"),
+					resource.TestCheckResourceAttr("propelauth_custom_domain.test", "domain", "example.com"),
+					resource.TestCheckResourceAttr("propelauth_custom_domain.test", "subdomain", "app"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "txt_record_key"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "txt_record_value"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "cname_record_key"),
+					resource.TestCheckResourceAttrSet("propelauth_custom_domain.test", "cname_record_value"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccCustomDomainResourceConfig(domain string, subdomain *string, environment string) string {
+	if subdomain != nil {
+		return providerConfig + fmt.Sprintf(`
+resource "propelauth_custom_domain" "test" {
+  environment = %[1]q
+  domain = %[2]q
+  subdomain = %[3]q
+}
+`, environment, domain, *subdomain)
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "propelauth_custom_domain" "test" {
+  environment = %[1]q
+  domain = %[2]q
+}
+`, environment, domain)
+}

--- a/internal/provider/custom_domain_verification_resource.go
+++ b/internal/provider/custom_domain_verification_resource.go
@@ -1,0 +1,187 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"terraform-provider-propelauth/internal/propelauth"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &customDomainVerificationResource{}
+var _ resource.ResourceWithConfigure   = &customDomainVerificationResource{}
+
+func NewCustomDomainVerificationResource() resource.Resource {
+	return &customDomainVerificationResource{}
+}
+
+// customDomainVerificationResource defines the resource implementation.
+type customDomainVerificationResource struct {
+	client *propelauth.PropelAuthClient
+}
+
+// projectInfoResourceModel describes the resource data model.
+type customDomainVerificationResourceModel struct {
+	Environment types.String `tfsdk:"environment"`
+	IsVerified types.Bool `tfsdk:"is_verified"`
+}
+
+func (r *customDomainVerificationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_custom_domain_verification"
+}
+
+func (r *customDomainVerificationResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		Description: "Custom Domain Verification resource. This is for verifying a custom domain for Production or Staging.",
+		Attributes: map[string]schema.Attribute{
+			"environment": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("Staging", "Prod", "PendingStaging", "PendingProd"),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "The environment for which you are configuring the custom domain. Accepted values are `Staging`, `Prod`, `PendingStaging`, and `PendingProd`. Use the `Pending` environments for switching.",
+			},
+			"is_verified": schema.BoolAttribute{
+				Computed: true,
+				Description: "Whether the custom domain has been verified.",
+			},
+		},
+	}
+}
+
+func (r *customDomainVerificationResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*propelauth.PropelAuthClient)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *propelauth.PropelAuthClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *customDomainVerificationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan customDomainVerificationResourceModel
+
+	// Read Terraform plan data into the model
+	diags := req.Plan.Get(ctx, &plan)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+	// Verify the custom domain
+	environment := plan.Environment.ValueString()
+	err := r.client.VerifyCustomDomainInfo(environment)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error verifying custom domain",
+			"Could not verify custom domain, unexpected error: " + err.Error(),
+		)
+		return
+	}
+
+	// Call the read method to get the updated state
+	customDomainInfo, err := r.client.GetCustomDomainInfo(environment)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error getting custom domain info",
+			"Could not get custom domain info, unexpected error: " + err.Error(),
+		)
+		return
+	}
+
+	// Set the data from the state into the response
+	plan.IsVerified = types.BoolValue(customDomainInfo.IsVerified)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *customDomainVerificationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Read the data from the state
+	var state customDomainVerificationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get the custom domain info
+	environment := state.Environment.ValueString()
+	customDomainInfo, err := r.client.GetCustomDomainInfo(environment)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error getting custom domain info",
+			"Could not get custom domain info, unexpected error: " + err.Error(),
+		)
+		return
+	}
+
+	// Write logs using the tflog package
+	// Documentation: https://terraform.io/plugin/log
+	tflog.Trace(ctx, "read a custom_domain resource")
+
+	// Set the data from the state into the response
+	state.IsVerified = types.BoolValue(customDomainInfo.IsVerified)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *customDomainVerificationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan customDomainVerificationResourceModel
+
+	// Read Terraform plan data into the model
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Verify the custom domain
+	environment := plan.Environment.ValueString()
+	err := r.client.VerifyCustomDomainInfo(environment)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error verifying custom domain",
+			"Could not verify custom domain, unexpected error: " + err.Error(),
+		)
+		return
+	}
+
+	// Call the read method to get the updated state
+	customDomainInfo, err := r.client.GetCustomDomainInfo(environment)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error getting custom domain info",
+			"Could not get custom domain info, unexpected error: " + err.Error(),
+		)
+		return
+	}
+
+	// Set the data from the state into the response
+	plan.IsVerified = types.BoolValue(customDomainInfo.IsVerified)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *customDomainVerificationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	tflog.Trace(ctx, "deleted a custom_domain resource")
+}

--- a/internal/provider/custom_domain_verification_resource.go
+++ b/internal/provider/custom_domain_verification_resource.go
@@ -98,7 +98,7 @@ func (r *customDomainVerificationResource) Create(ctx context.Context, req resou
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error verifying custom domain",
-			"Could not verify custom domain, unexpected error: " + err.Error(),
+			"Could not verify custom domain, please check the domain records and try again.",
 		)
 		return
 	}
@@ -145,7 +145,7 @@ func (r *customDomainVerificationResource) Update(ctx context.Context,  req reso
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error verifying custom domain",
-			"Could not verify custom domain, unexpected error: " + err.Error(),
+			"Could not verify custom domain, please check the domain records and try again.",
 		)
 		return
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -199,6 +199,7 @@ func (p *propelauthProvider) Resources(ctx context.Context) []func() resource.Re
         NewApiKeySettingsResource,
         NewFeIntegrationResource,
         NewBeApiKeyResource,
+        NewCustomDomainResource,
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -200,6 +200,7 @@ func (p *propelauthProvider) Resources(ctx context.Context) []func() resource.Re
         NewFeIntegrationResource,
         NewBeApiKeyResource,
         NewCustomDomainResource,
+        NewCustomDomainVerificationResource,
 	}
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -16,9 +16,9 @@ const (
     // such as updating the Makefile and running the testing through that tool.
     providerConfig = `
 provider "propelauth" {
-   tenant_id = "e1dc8461-5d8a-4bad-a929-19745de693f4"
-   project_id = "5a5f7a4f-1a51-4312-bbbe-4126cceab59b"
-   api_key = "c557308180b7da18d7e0e9cbd2ae3b36833c0165b5158c439efe59662df01701c2e23b00211b9c25b5223e51417f323b"
+#   tenant_id = "<PROPELAUTH_TENANT_ID>"
+#   project_id = "<PROPELAUTH_PROJECT_ID>"
+#   api_key = "<PROPELAUTH_API_KEY>"
 }
 `
 )

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -5,6 +5,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
+// PROPELAUTH_TENANT_ID=e1dc8461-5d8a-4bad-a929-19745de693f4
+// PROPELAUTH_PROJECT_ID=5a5f7a4f-1a51-4312-bbbe-4126cceab59b
+// PROPELAUTH_API_KEY=c557308180b7da18d7e0e9cbd2ae3b36833c0165b5158c439efe59662df01701c2e23b00211b9c25b5223e51417f323b
+
 const (
     // providerConfig is a shared configuration to combine with the actual
     // test configuration so the PropelAuth client is properly configured.
@@ -12,9 +16,9 @@ const (
     // such as updating the Makefile and running the testing through that tool.
     providerConfig = `
 provider "propelauth" {
-#   tenant_id = "<PROPELAUTH_TENANT_ID>"
-#   project_id = "<PROPELAUTH_PROJECT_ID>"
-#   api_key = "<PROPELAUTH_API_KEY>"
+   tenant_id = "e1dc8461-5d8a-4bad-a929-19745de693f4"
+   project_id = "5a5f7a4f-1a51-4312-bbbe-4126cceab59b"
+   api_key = "c557308180b7da18d7e0e9cbd2ae3b36833c0165b5158c439efe59662df01701c2e23b00211b9c25b5223e51417f323b"
 }
 `
 )


### PR DESCRIPTION
# Smoke Tests
  All smoke tests performed were completely managed through TF. No updates were made to the dashboard to check existing state. It is expected that all will be done in an empty TF state.

* With no verified prod realm, calling terraform plan/apply created a new unverified domain for sharpenchess.com. The verification, however, failed as there code was incorrect. 
* When updating the domain to sharpenchess2.com, the domain and txt code was updated as expected. The verification failed again as expected.
* When adding a subdomain, the subdomain was updated. The verification failed again as expected.
* When changing the domain back to sharpenchess.com and removing the subdomain, all was updated as expected. The verification failed again as expected.
* When changing the verification code manually in the DB to the correct one, and running `terraform apply`, the prod environment was verified successfully. 
* When running `terraform plan`, no changes were found, as expected.
* When changing the domain to `itailevi.com`, the state was updated to the new records and domain. The verification failed, as expected.
* When changing the subdomain to the pending prod env, the state was updated to add the new subdomain, and verification failed as expected.
* When removing the subdomain, the state was updated as expected, and the verification failed again.
* When updating the domain to a different one and back, all states were updated as expected, and all verifications failed.
* When changing the verification code manually in the DB to the correct one, and running `terraform apply`, the prod environment was switched successfully. 
* When changing the environment to "Staging" the resource was deleted and recreated to track staging environment. 