### PR TITLE
[TIC-958] Signup domain allowlist/blocklist

### DIFF
--- a/docs/resources/basic_auth_configuration.md
+++ b/docs/resources/basic_auth_configuration.md
@@ -25,10 +25,14 @@ resource "propelauth_basic_auth_configuration" "example" {
 
 ### Optional
 
-- `allow_users_to_signup_with_personal_email` (Boolean) If true, your users will be able to sign up using personal email domains (@gmail.com, @yahoo.com, etc.).The default setting is true.
+- `allow_users_to_signup_with_personal_email` (Boolean) If true, your users will be able to sign up using personal email domains (@gmail.com, @yahoo.com, etc.).The default setting is true. This is only enabled if `signup_domain_allowlist_enabled` is false.
 - `has_password_login` (Boolean) If true, your users will be able to log in using their email and password. The default setting is true.
 - `has_passwordless_login` (Boolean) If true, your users will be able to log in using a magic link sent to their email. The default setting is false.
 - `include_login_method` (Boolean) If true, the login method will be included in the access token. The default setting is false.See `https://docs.propelauth.com/overview/user-management/user-properties#login-method-property` for more information.
+- `signup_domain_allowlist` (List of String) A list of email domains that are allowed to sign up. This is only used if `signup_domain_allowlist_enabled` is true.
+- `signup_domain_allowlist_enabled` (Boolean) If true, only users with email domains in the allowlist will be able to sign up. The default setting is false.
+- `signup_domain_blocklist` (List of String) A list of email domains that are blocked from signing up. This is only used if `signup_domain_blocklist_enabled` is true and `signup_domain_allowlist_enabled` is false.
+- `signup_domain_blocklist_enabled` (Boolean) If true, users with email domains in the blocklist will not be able to sign up. The default setting is false. This is only used if `signup_domain_allowlist_enabled` is false.
 - `user_autologout_seconds` (Number) The number of seconds before a user is automatically logged out. The default setting is 1209600 (14 days).See also "user_autologout_type" for more information.
 - `user_autologout_type` (String) This sets the behavior for when the counting for "user_autologout_seconds" starts. Valid values are "AfterInactivity" and the stricter "AfterLogin". The default setting is "AfterInactivity".
 - `users_can_change_email` (Boolean) If true, your users will be able to change their email address. The default setting is true.

--- a/docs/resources/basic_auth_configuration.md
+++ b/docs/resources/basic_auth_configuration.md
@@ -29,8 +29,8 @@ resource "propelauth_basic_auth_configuration" "example" {
 - `has_password_login` (Boolean) If true, your users will be able to log in using their email and password. The default setting is true.
 - `has_passwordless_login` (Boolean) If true, your users will be able to log in using a magic link sent to their email. The default setting is false.
 - `include_login_method` (Boolean) If true, the login method will be included in the access token. The default setting is false.See `https://docs.propelauth.com/overview/user-management/user-properties#login-method-property` for more information.
-- `signup_domain_allowlist` (List of String) A list of email domains that are allowed to sign up. This is only used if `signup_domain_allowlist_enabled` is true.
-- `signup_domain_blocklist` (List of String) A list of email domains that are blocked from signing up. This is only used if `signup_domain_blocklist_enabled` is true and `signup_domain_allowlist` is empty.
+- `signup_domain_allowlist` (List of String) A list of email domains that are allowed to sign up.
+- `signup_domain_blocklist` (List of String) A list of email domains that are blocked from signing up. This is only used if `signup_domain_allowlist` is empty.
 - `user_autologout_seconds` (Number) The number of seconds before a user is automatically logged out. The default setting is 1209600 (14 days).See also "user_autologout_type" for more information.
 - `user_autologout_type` (String) This sets the behavior for when the counting for "user_autologout_seconds" starts. Valid values are "AfterInactivity" and the stricter "AfterLogin". The default setting is "AfterInactivity".
 - `users_can_change_email` (Boolean) If true, your users will be able to change their email address. The default setting is true.

--- a/docs/resources/basic_auth_configuration.md
+++ b/docs/resources/basic_auth_configuration.md
@@ -25,14 +25,12 @@ resource "propelauth_basic_auth_configuration" "example" {
 
 ### Optional
 
-- `allow_users_to_signup_with_personal_email` (Boolean) If true, your users will be able to sign up using personal email domains (@gmail.com, @yahoo.com, etc.).The default setting is true. This is only enabled if `signup_domain_allowlist_enabled` is false.
+- `allow_users_to_signup_with_personal_email` (Boolean) If true, your users will be able to sign up using personal email domains (@gmail.com, @yahoo.com, etc.).The default setting is true. This is only enabled if `signup_domain_allowlist` is empty.
 - `has_password_login` (Boolean) If true, your users will be able to log in using their email and password. The default setting is true.
 - `has_passwordless_login` (Boolean) If true, your users will be able to log in using a magic link sent to their email. The default setting is false.
 - `include_login_method` (Boolean) If true, the login method will be included in the access token. The default setting is false.See `https://docs.propelauth.com/overview/user-management/user-properties#login-method-property` for more information.
 - `signup_domain_allowlist` (List of String) A list of email domains that are allowed to sign up. This is only used if `signup_domain_allowlist_enabled` is true.
-- `signup_domain_allowlist_enabled` (Boolean) If true, only users with email domains in the allowlist will be able to sign up. The default setting is false.
-- `signup_domain_blocklist` (List of String) A list of email domains that are blocked from signing up. This is only used if `signup_domain_blocklist_enabled` is true and `signup_domain_allowlist_enabled` is false.
-- `signup_domain_blocklist_enabled` (Boolean) If true, users with email domains in the blocklist will not be able to sign up. The default setting is false. This is only used if `signup_domain_allowlist_enabled` is false.
+- `signup_domain_blocklist` (List of String) A list of email domains that are blocked from signing up. This is only used if `signup_domain_blocklist_enabled` is true and `signup_domain_allowlist` is empty.
 - `user_autologout_seconds` (Number) The number of seconds before a user is automatically logged out. The default setting is 1209600 (14 days).See also "user_autologout_type" for more information.
 - `user_autologout_type` (String) This sets the behavior for when the counting for "user_autologout_seconds" starts. Valid values are "AfterInactivity" and the stricter "AfterLogin". The default setting is "AfterInactivity".
 - `users_can_change_email` (Boolean) If true, your users will be able to change their email address. The default setting is true.

--- a/internal/propelauth/client.go
+++ b/internal/propelauth/client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const BaseURLTemplate string = "https://api.propelauth.com/iac/%s/project/%s"
+const BaseURLTemplate string = "https://api.propelauth.localhost/iac/%s/project/%s"
 
 // PropelAuthClient - Client for the PropelAuth API to manage an existing project and all its resources.
 type PropelAuthClient struct {

--- a/internal/propelauth/client.go
+++ b/internal/propelauth/client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const BaseURLTemplate string = "https://api.propelauth.localhost/iac/%s/project/%s"
+const BaseURLTemplate string = "https://api.propelauth.com/iac/%s/project/%s"
 
 // PropelAuthClient - Client for the PropelAuth API to manage an existing project and all its resources.
 type PropelAuthClient struct {

--- a/internal/propelauth/models.go
+++ b/internal/propelauth/models.go
@@ -18,6 +18,10 @@ type ProjectInfoUpdateRequest struct {
 
 type EnvironmentConfigUpdate struct {
 	AllowUsersToSignupWithPersonalEmail *bool         `json:"allow_users_to_signup_with_personal_email,omitempty"`
+	SignupDomainAllowlistEnabled		*bool         `json:"signup_domain_allowlist_enabled,omitempty"`
+	SignupDomainAllowlist				[]string      `json:"signup_domain_allowlist,omitempty"`
+	SignupDomainBlocklistEnabled		*bool         `json:"signup_domain_blocklist_enabled,omitempty"`
+	SignupDomainBlocklist				[]string      `json:"signup_domain_blocklist,omitempty"`
 	HasPasswordLogin                    *bool         `json:"has_password_login,omitempty"`
 	HasPasswordlessLogin                *bool         `json:"has_passwordless_login,omitempty"`
 	WaitlistUsersEnabled                *bool         `json:"waitlist_users_enabled,omitempty"`
@@ -48,6 +52,10 @@ type EnvironmentConfigUpdate struct {
 
 type EnvironmentConfigResponse struct {
 	AllowUsersToSignupWithPersonalEmail bool         `json:"allow_users_to_signup_with_personal_email"`
+	SignupDomainAllowlistEnabled        bool         `json:"signup_domain_allowlist_enabled"`
+	SignupDomainAllowlist               []string     `json:"signup_domain_allowlist"`
+	SignupDomainBlocklistEnabled        bool         `json:"signup_domain_blocklist_enabled"`
+	SignupDomainBlocklist               []string     `json:"signup_domain_blocklist"`
 	HasPasswordLogin                    bool         `json:"has_password_login"`
 	HasPasswordlessLogin                bool         `json:"has_passwordless_login"`
 	WaitlistUsersEnabled                bool         `json:"waitlist_users_enabled"`

--- a/internal/propelauth/models.go
+++ b/internal/propelauth/models.go
@@ -18,10 +18,10 @@ type ProjectInfoUpdateRequest struct {
 
 type EnvironmentConfigUpdate struct {
 	AllowUsersToSignupWithPersonalEmail *bool         `json:"allow_users_to_signup_with_personal_email,omitempty"`
-	SignupDomainAllowlistEnabled		*bool         `json:"signup_domain_allowlist_enabled,omitempty"`
-	SignupDomainAllowlist				[]string      `json:"signup_domain_allowlist,omitempty"`
-	SignupDomainBlocklistEnabled		*bool         `json:"signup_domain_blocklist_enabled,omitempty"`
-	SignupDomainBlocklist				[]string      `json:"signup_domain_blocklist,omitempty"`
+	SignupDomainAllowlistEnabled        *bool         `json:"signup_domain_allowlist_enabled,omitempty"`
+	SignupDomainAllowlist               []string      `json:"signup_domain_allowlist,omitempty"`
+	SignupDomainBlocklistEnabled        *bool         `json:"signup_domain_blocklist_enabled,omitempty"`
+	SignupDomainBlocklist               []string      `json:"signup_domain_blocklist,omitempty"`
 	HasPasswordLogin                    *bool         `json:"has_password_login,omitempty"`
 	HasPasswordlessLogin                *bool         `json:"has_passwordless_login,omitempty"`
 	WaitlistUsersEnabled                *bool         `json:"waitlist_users_enabled,omitempty"`

--- a/internal/provider/basic_auth_configuration_resource.go
+++ b/internal/provider/basic_auth_configuration_resource.go
@@ -29,19 +29,19 @@ type basicAuthConfigurationResource struct {
 
 // basicAuthConfigurationResourceModel describes the resource data model.
 type basicAuthConfigurationResourceModel struct {
-	AllowUsersToSignupWithPersonalEmail types.Bool   	`tfsdk:"allow_users_to_signup_with_personal_email"`
-	SignupDomainAllowlistEnabled		types.Bool   	`tfsdk:"signup_domain_allowlist_enabled"`
-	SignupDomainAllowlist				[]types.String 	`tfsdk:"signup_domain_allowlist"`
-	SignupDomainBlocklistEnabled		types.Bool   	`tfsdk:"signup_domain_blocklist_enabled"`
-	SignupDomainBlocklist				[]types.String 	`tfsdk:"signup_domain_blocklist"`
-	HasPasswordLogin                    types.Bool   	`tfsdk:"has_password_login"`
-	HasPasswordlessLogin                types.Bool   	`tfsdk:"has_passwordless_login"`
-	WaitlistUsersEnabled                types.Bool   	`tfsdk:"waitlist_users_enabled"`
-	UserAutologoutSeconds               types.Int64  	`tfsdk:"user_autologout_seconds"`
-	UserAutologoutType                  types.String 	`tfsdk:"user_autologout_type"`
-	UsersCanDeleteOwnAccount            types.Bool   	`tfsdk:"users_can_delete_own_account"`
-	UsersCanChangeEmail                 types.Bool   	`tfsdk:"users_can_change_email"`
-	IncludeLoginMethod                  types.Bool   	`tfsdk:"include_login_method"`
+	AllowUsersToSignupWithPersonalEmail types.Bool     `tfsdk:"allow_users_to_signup_with_personal_email"`
+	SignupDomainAllowlistEnabled        types.Bool     `tfsdk:"signup_domain_allowlist_enabled"`
+	SignupDomainAllowlist               []types.String `tfsdk:"signup_domain_allowlist"`
+	SignupDomainBlocklistEnabled        types.Bool     `tfsdk:"signup_domain_blocklist_enabled"`
+	SignupDomainBlocklist               []types.String `tfsdk:"signup_domain_blocklist"`
+	HasPasswordLogin                    types.Bool     `tfsdk:"has_password_login"`
+	HasPasswordlessLogin                types.Bool     `tfsdk:"has_passwordless_login"`
+	WaitlistUsersEnabled                types.Bool     `tfsdk:"waitlist_users_enabled"`
+	UserAutologoutSeconds               types.Int64    `tfsdk:"user_autologout_seconds"`
+	UserAutologoutType                  types.String   `tfsdk:"user_autologout_type"`
+	UsersCanDeleteOwnAccount            types.Bool     `tfsdk:"users_can_delete_own_account"`
+	UsersCanChangeEmail                 types.Bool     `tfsdk:"users_can_change_email"`
+	IncludeLoginMethod                  types.Bool     `tfsdk:"include_login_method"`
 }
 
 func (r *basicAuthConfigurationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -151,8 +151,8 @@ func (r *basicAuthConfigurationResource) Create(ctx context.Context, req resourc
 	// Update the configuration in PropelAuth
 	environmentConfigUpdate := propelauth.EnvironmentConfigUpdate{
 		AllowUsersToSignupWithPersonalEmail: plan.AllowUsersToSignupWithPersonalEmail.ValueBoolPointer(),
-		SignupDomainAllowlistEnabled: 	  	 plan.SignupDomainAllowlistEnabled.ValueBoolPointer(),
-		SignupDomainBlocklistEnabled: 	  	 plan.SignupDomainBlocklistEnabled.ValueBoolPointer(),
+		SignupDomainAllowlistEnabled:        plan.SignupDomainAllowlistEnabled.ValueBoolPointer(),
+		SignupDomainBlocklistEnabled:        plan.SignupDomainBlocklistEnabled.ValueBoolPointer(),
 		HasPasswordLogin:                    plan.HasPasswordLogin.ValueBoolPointer(),
 		HasPasswordlessLogin:                plan.HasPasswordlessLogin.ValueBoolPointer(),
 		WaitlistUsersEnabled:                plan.WaitlistUsersEnabled.ValueBoolPointer(),
@@ -306,7 +306,7 @@ func (r *basicAuthConfigurationResource) Create(ctx context.Context, req resourc
 				resp.Diagnostics.AddError(
 					"Error updating basic auth configuration",
 					"SignupDomainBlocklist failed to update. The `signup_domain_blocklist` is instead "+fmt.Sprintf("%v", environmentConfigResponse.SignupDomainBlocklist),
-				)	
+				)
 				return
 			}
 		}
@@ -385,8 +385,8 @@ func (r *basicAuthConfigurationResource) Update(ctx context.Context, req resourc
 	// Update the configuration in PropelAuth
 	environmentConfigUpdate := propelauth.EnvironmentConfigUpdate{
 		AllowUsersToSignupWithPersonalEmail: plan.AllowUsersToSignupWithPersonalEmail.ValueBoolPointer(),
-		SignupDomainAllowlistEnabled: 	  	 plan.SignupDomainAllowlistEnabled.ValueBoolPointer(),
-		SignupDomainBlocklistEnabled: 	  	 plan.SignupDomainBlocklistEnabled.ValueBoolPointer(),
+		SignupDomainAllowlistEnabled:        plan.SignupDomainAllowlistEnabled.ValueBoolPointer(),
+		SignupDomainBlocklistEnabled:        plan.SignupDomainBlocklistEnabled.ValueBoolPointer(),
 		HasPasswordLogin:                    plan.HasPasswordLogin.ValueBoolPointer(),
 		HasPasswordlessLogin:                plan.HasPasswordlessLogin.ValueBoolPointer(),
 		WaitlistUsersEnabled:                plan.WaitlistUsersEnabled.ValueBoolPointer(),

--- a/internal/provider/basic_auth_configuration_resource.go
+++ b/internal/provider/basic_auth_configuration_resource.go
@@ -29,15 +29,19 @@ type basicAuthConfigurationResource struct {
 
 // basicAuthConfigurationResourceModel describes the resource data model.
 type basicAuthConfigurationResourceModel struct {
-	AllowUsersToSignupWithPersonalEmail types.Bool   `tfsdk:"allow_users_to_signup_with_personal_email"`
-	HasPasswordLogin                    types.Bool   `tfsdk:"has_password_login"`
-	HasPasswordlessLogin                types.Bool   `tfsdk:"has_passwordless_login"`
-	WaitlistUsersEnabled                types.Bool   `tfsdk:"waitlist_users_enabled"`
-	UserAutologoutSeconds               types.Int64  `tfsdk:"user_autologout_seconds"`
-	UserAutologoutType                  types.String `tfsdk:"user_autologout_type"`
-	UsersCanDeleteOwnAccount            types.Bool   `tfsdk:"users_can_delete_own_account"`
-	UsersCanChangeEmail                 types.Bool   `tfsdk:"users_can_change_email"`
-	IncludeLoginMethod                  types.Bool   `tfsdk:"include_login_method"`
+	AllowUsersToSignupWithPersonalEmail types.Bool   	`tfsdk:"allow_users_to_signup_with_personal_email"`
+	SignupDomainAllowlistEnabled		types.Bool   	`tfsdk:"signup_domain_allowlist_enabled"`
+	SignupDomainAllowlist				[]types.String 	`tfsdk:"signup_domain_allowlist"`
+	SignupDomainBlocklistEnabled		types.Bool   	`tfsdk:"signup_domain_blocklist_enabled"`
+	SignupDomainBlocklist				[]types.String 	`tfsdk:"signup_domain_blocklist"`
+	HasPasswordLogin                    types.Bool   	`tfsdk:"has_password_login"`
+	HasPasswordlessLogin                types.Bool   	`tfsdk:"has_passwordless_login"`
+	WaitlistUsersEnabled                types.Bool   	`tfsdk:"waitlist_users_enabled"`
+	UserAutologoutSeconds               types.Int64  	`tfsdk:"user_autologout_seconds"`
+	UserAutologoutType                  types.String 	`tfsdk:"user_autologout_type"`
+	UsersCanDeleteOwnAccount            types.Bool   	`tfsdk:"users_can_delete_own_account"`
+	UsersCanChangeEmail                 types.Bool   	`tfsdk:"users_can_change_email"`
+	IncludeLoginMethod                  types.Bool   	`tfsdk:"include_login_method"`
 }
 
 func (r *basicAuthConfigurationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -52,7 +56,25 @@ func (r *basicAuthConfigurationResource) Schema(ctx context.Context, req resourc
 			"allow_users_to_signup_with_personal_email": schema.BoolAttribute{
 				Optional: true,
 				Description: "If true, your users will be able to sign up using personal email domains (@gmail.com, @yahoo.com, etc.)." +
-					"The default setting is true.",
+					"The default setting is true. This is only enabled if `signup_domain_allowlist_enabled` is false.",
+			},
+			"signup_domain_allowlist_enabled": schema.BoolAttribute{
+				Optional:    true,
+				Description: "If true, only users with email domains in the allowlist will be able to sign up. The default setting is false.",
+			},
+			"signup_domain_allowlist": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Description: "A list of email domains that are allowed to sign up. This is only used if `signup_domain_allowlist_enabled` is true.",
+			},
+			"signup_domain_blocklist_enabled": schema.BoolAttribute{
+				Optional:    true,
+				Description: "If true, users with email domains in the blocklist will not be able to sign up. The default setting is false. This is only used if `signup_domain_allowlist_enabled` is false.",
+			},
+			"signup_domain_blocklist": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Description: "A list of email domains that are blocked from signing up. This is only used if `signup_domain_blocklist_enabled` is true and `signup_domain_allowlist_enabled` is false.",
 			},
 			"has_password_login": schema.BoolAttribute{
 				Optional:    true,
@@ -129,6 +151,8 @@ func (r *basicAuthConfigurationResource) Create(ctx context.Context, req resourc
 	// Update the configuration in PropelAuth
 	environmentConfigUpdate := propelauth.EnvironmentConfigUpdate{
 		AllowUsersToSignupWithPersonalEmail: plan.AllowUsersToSignupWithPersonalEmail.ValueBoolPointer(),
+		SignupDomainAllowlistEnabled: 	  	 plan.SignupDomainAllowlistEnabled.ValueBoolPointer(),
+		SignupDomainBlocklistEnabled: 	  	 plan.SignupDomainBlocklistEnabled.ValueBoolPointer(),
 		HasPasswordLogin:                    plan.HasPasswordLogin.ValueBoolPointer(),
 		HasPasswordlessLogin:                plan.HasPasswordlessLogin.ValueBoolPointer(),
 		WaitlistUsersEnabled:                plan.WaitlistUsersEnabled.ValueBoolPointer(),
@@ -137,6 +161,20 @@ func (r *basicAuthConfigurationResource) Create(ctx context.Context, req resourc
 		UsersCanDeleteOwnAccount:            plan.UsersCanDeleteOwnAccount.ValueBoolPointer(),
 		UsersCanChangeEmail:                 plan.UsersCanChangeEmail.ValueBoolPointer(),
 		IncludeLoginMethod:                  plan.IncludeLoginMethod.ValueBoolPointer(),
+	}
+
+	if plan.SignupDomainAllowlist != nil {
+		environmentConfigUpdate.SignupDomainAllowlist = make([]string, len(plan.SignupDomainAllowlist))
+		for i, domain := range plan.SignupDomainAllowlist {
+			environmentConfigUpdate.SignupDomainAllowlist[i] = domain.ValueString()
+		}
+	}
+
+	if plan.SignupDomainBlocklist != nil {
+		environmentConfigUpdate.SignupDomainBlocklist = make([]string, len(plan.SignupDomainBlocklist))
+		for i, domain := range plan.SignupDomainBlocklist {
+			environmentConfigUpdate.SignupDomainBlocklist[i] = domain.ValueString()
+		}
 	}
 
 	environmentConfigResponse, err := r.client.UpdateEnvironmentConfig(&environmentConfigUpdate)
@@ -220,6 +258,58 @@ func (r *basicAuthConfigurationResource) Create(ctx context.Context, req resourc
 			"IncludeLoginMethod failed to update. The `include_login_method` is instead "+fmt.Sprintf("%t", environmentConfigResponse.IncludeLoginMethod),
 		)
 		return
+	}
+	if plan.SignupDomainAllowlistEnabled.ValueBoolPointer() != nil &&
+		plan.SignupDomainAllowlistEnabled.ValueBool() != environmentConfigResponse.SignupDomainAllowlistEnabled {
+		resp.Diagnostics.AddError(
+			"Error updating basic auth configuration",
+			"SignupDomainAllowlistEnabled failed to update. The `signup_domain_allowlist_enabled` is instead "+fmt.Sprintf("%t", environmentConfigResponse.SignupDomainAllowlistEnabled),
+		)
+		return
+	}
+	if plan.SignupDomainBlocklistEnabled.ValueBoolPointer() != nil &&
+		plan.SignupDomainBlocklistEnabled.ValueBool() != environmentConfigResponse.SignupDomainBlocklistEnabled {
+		resp.Diagnostics.AddError(
+			"Error updating basic auth configuration",
+			"SignupDomainBlocklistEnabled failed to update. The `signup_domain_blocklist_enabled` is instead "+fmt.Sprintf("%t", environmentConfigResponse.SignupDomainBlocklistEnabled),
+		)
+		return
+	}
+	if plan.SignupDomainAllowlist != nil {
+		if len(plan.SignupDomainAllowlist) != len(environmentConfigResponse.SignupDomainAllowlist) {
+			resp.Diagnostics.AddError(
+				"Error updating basic auth configuration",
+				"SignupDomainAllowlist failed to update. The `signup_domain_allowlist` is instead "+fmt.Sprintf("%v", environmentConfigResponse.SignupDomainAllowlist),
+			)
+			return
+		}
+		for i, domain := range plan.SignupDomainAllowlist {
+			if domain.ValueString() != environmentConfigResponse.SignupDomainAllowlist[i] {
+				resp.Diagnostics.AddError(
+					"Error updating basic auth configuration",
+					"SignupDomainAllowlist failed to update. The `signup_domain_allowlist` is instead "+fmt.Sprintf("%v", environmentConfigResponse.SignupDomainAllowlist),
+				)
+				return
+			}
+		}
+	}
+	if plan.SignupDomainBlocklist != nil {
+		if len(plan.SignupDomainBlocklist) != len(environmentConfigResponse.SignupDomainBlocklist) {
+			resp.Diagnostics.AddError(
+				"Error updating basic auth configuration",
+				"SignupDomainBlocklist failed to update. The `signup_domain_blocklist` is instead "+fmt.Sprintf("%v", environmentConfigResponse.SignupDomainBlocklist),
+			)
+			return
+		}
+		for i, domain := range plan.SignupDomainBlocklist {
+			if domain.ValueString() != environmentConfigResponse.SignupDomainBlocklist[i] {
+				resp.Diagnostics.AddError(
+					"Error updating basic auth configuration",
+					"SignupDomainBlocklist failed to update. The `signup_domain_blocklist` is instead "+fmt.Sprintf("%v", environmentConfigResponse.SignupDomainBlocklist),
+				)	
+				return
+			}
+		}
 	}
 
 	// Write logs using the tflog package
@@ -295,6 +385,8 @@ func (r *basicAuthConfigurationResource) Update(ctx context.Context, req resourc
 	// Update the configuration in PropelAuth
 	environmentConfigUpdate := propelauth.EnvironmentConfigUpdate{
 		AllowUsersToSignupWithPersonalEmail: plan.AllowUsersToSignupWithPersonalEmail.ValueBoolPointer(),
+		SignupDomainAllowlistEnabled: 	  	 plan.SignupDomainAllowlistEnabled.ValueBoolPointer(),
+		SignupDomainBlocklistEnabled: 	  	 plan.SignupDomainBlocklistEnabled.ValueBoolPointer(),
 		HasPasswordLogin:                    plan.HasPasswordLogin.ValueBoolPointer(),
 		HasPasswordlessLogin:                plan.HasPasswordlessLogin.ValueBoolPointer(),
 		WaitlistUsersEnabled:                plan.WaitlistUsersEnabled.ValueBoolPointer(),
@@ -303,6 +395,20 @@ func (r *basicAuthConfigurationResource) Update(ctx context.Context, req resourc
 		UsersCanDeleteOwnAccount:            plan.UsersCanDeleteOwnAccount.ValueBoolPointer(),
 		UsersCanChangeEmail:                 plan.UsersCanChangeEmail.ValueBoolPointer(),
 		IncludeLoginMethod:                  plan.IncludeLoginMethod.ValueBoolPointer(),
+	}
+
+	if plan.SignupDomainAllowlist != nil {
+		environmentConfigUpdate.SignupDomainAllowlist = make([]string, len(plan.SignupDomainAllowlist))
+		for i, domain := range plan.SignupDomainAllowlist {
+			environmentConfigUpdate.SignupDomainAllowlist[i] = domain.ValueString()
+		}
+	}
+
+	if plan.SignupDomainBlocklist != nil {
+		environmentConfigUpdate.SignupDomainBlocklist = make([]string, len(plan.SignupDomainBlocklist))
+		for i, domain := range plan.SignupDomainBlocklist {
+			environmentConfigUpdate.SignupDomainBlocklist[i] = domain.ValueString()
+		}
 	}
 
 	environmentConfigResponse, err := r.client.UpdateEnvironmentConfig(&environmentConfigUpdate)
@@ -386,6 +492,58 @@ func (r *basicAuthConfigurationResource) Update(ctx context.Context, req resourc
 			"IncludeLoginMethod failed to update. The `include_login_method` is instead "+fmt.Sprintf("%t", environmentConfigResponse.IncludeLoginMethod),
 		)
 		return
+	}
+	if plan.SignupDomainAllowlistEnabled.ValueBoolPointer() != nil &&
+		plan.SignupDomainAllowlistEnabled.ValueBool() != environmentConfigResponse.SignupDomainAllowlistEnabled {
+		resp.Diagnostics.AddError(
+			"Error updating basic auth configuration",
+			"SignupDomainAllowlistEnabled failed to update. The `signup_domain_allowlist_enabled` is instead "+fmt.Sprintf("%t", environmentConfigResponse.SignupDomainAllowlistEnabled),
+		)
+		return
+	}
+	if plan.SignupDomainBlocklistEnabled.ValueBoolPointer() != nil &&
+		plan.SignupDomainBlocklistEnabled.ValueBool() != environmentConfigResponse.SignupDomainBlocklistEnabled {
+		resp.Diagnostics.AddError(
+			"Error updating basic auth configuration",
+			"SignupDomainBlocklistEnabled failed to update. The `signup_domain_blocklist_enabled` is instead "+fmt.Sprintf("%t", environmentConfigResponse.SignupDomainBlocklistEnabled),
+		)
+		return
+	}
+	if plan.SignupDomainAllowlist != nil {
+		if len(plan.SignupDomainAllowlist) != len(environmentConfigResponse.SignupDomainAllowlist) {
+			resp.Diagnostics.AddError(
+				"Error updating basic auth configuration",
+				"SignupDomainAllowlist failed to update. The `signup_domain_allowlist` is instead "+fmt.Sprintf("%v", environmentConfigResponse.SignupDomainAllowlist),
+			)
+			return
+		}
+		for i, domain := range plan.SignupDomainAllowlist {
+			if domain.ValueString() != environmentConfigResponse.SignupDomainAllowlist[i] {
+				resp.Diagnostics.AddError(
+					"Error updating basic auth configuration",
+					"SignupDomainAllowlist failed to update. The `signup_domain_allowlist` is instead "+fmt.Sprintf("%v", environmentConfigResponse.SignupDomainAllowlist),
+				)
+				return
+			}
+		}
+	}
+	if plan.SignupDomainBlocklist != nil {
+		if len(plan.SignupDomainBlocklist) != len(environmentConfigResponse.SignupDomainBlocklist) {
+			resp.Diagnostics.AddError(
+				"Error updating basic auth configuration",
+				"SignupDomainBlocklist failed to update. The `signup_domain_blocklist` is instead "+fmt.Sprintf("%v", environmentConfigResponse.SignupDomainBlocklist),
+			)
+			return
+		}
+		for i, domain := range plan.SignupDomainBlocklist {
+			if domain.ValueString() != environmentConfigResponse.SignupDomainBlocklist[i] {
+				resp.Diagnostics.AddError(
+					"Error updating basic auth configuration",
+					"SignupDomainBlocklist failed to update. The `signup_domain_blocklist` is instead "+fmt.Sprintf("%v", environmentConfigResponse.SignupDomainBlocklist),
+				)
+				return
+			}
+		}
 	}
 
 	// Write logs using the tflog package

--- a/internal/provider/basic_auth_configuration_resource.go
+++ b/internal/provider/basic_auth_configuration_resource.go
@@ -58,24 +58,16 @@ func (r *basicAuthConfigurationResource) Schema(ctx context.Context, req resourc
 				Description: "If true, your users will be able to sign up using personal email domains (@gmail.com, @yahoo.com, etc.)." +
 					"The default setting is true. This is only enabled if `signup_domain_allowlist` is empty.",
 			},
-			// "signup_domain_allowlist_enabled": schema.BoolAttribute{
-			// 	Optional:    true,
-			// 	Description: "If true, only users with email domains in the allowlist will be able to sign up. The default setting is false.",
-			// },
 			"signup_domain_allowlist": schema.ListAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
-				Description: "A list of email domains that are allowed to sign up. This is only used if `signup_domain_allowlist_enabled` is true.",
+				Description: "A list of email domains that are allowed to sign up.",
 			},
 			"signup_domain_blocklist": schema.ListAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
-				Description: "A list of email domains that are blocked from signing up. This is only used if `signup_domain_blocklist_enabled` is true and `signup_domain_allowlist` is empty.",
+				Description: "A list of email domains that are blocked from signing up. This is only used if `signup_domain_allowlist` is empty.",
 			},
-			// "signup_domain_blocklist_enabled": schema.BoolAttribute{
-			// 	Optional:    true,
-			// 	Description: "If true, users with email domains in the blocklist will not be able to sign up. The default setting is false. This is only used if `signup_domain_allowlist_enabled` is false.",
-			// },
 			"has_password_login": schema.BoolAttribute{
 				Optional:    true,
 				Description: "If true, your users will be able to log in using their email and password. The default setting is true.",


### PR DESCRIPTION
# Background

This PR introduces the new env. config fields `signup_domain_allowlist_enabled`, `signup_domain_allowlist`, `signup_domain_blocklist_enabled`, and `signup_domain_blocklist`.

Logic was smoke-tested with the following resource, with all create, read, and update functionality working as expected:

```tf
terraform {
  required_providers {
    propelauth = {
      source = "registry.terraform.io/propelauth/propelauth"
    }
  }
}

provider "propelauth" {
...
}

resource "propelauth_basic_auth_configuration" "example" {
  signup_domain_allowlist         = ["example.com", "a.example.com"]
 # or  signup_domain_blocklist         = ["b.example.com"]
}
```