### PR TITLE
use "" as default value for SplitScreen text values to match BE

### DIFF
--- a/internal/provider/theme_resource.go
+++ b/internal/provider/theme_resource.go
@@ -341,11 +341,15 @@ func (r *themeResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							},
 							"header": schema.StringAttribute{
 								Optional: true,
+								Computed: true,
+								Default:  stringdefault.StaticString(""),
 								Description: "The header text displayed on the side of the screen opposite the login components. " +
 									"This is only displayed if `content_type` is `Text`",
 							},
 							"subheader": schema.StringAttribute{
 								Optional: true,
+								Computed: true,
+								Default:  stringdefault.StaticString(""),
 								Description: "The subheader text displayed on the side of the screen opposite the login components. " +
 									"This is only displayed if `content_type` is `Text`",
 							},


### PR DESCRIPTION
Resolves [this issue](https://github.com/PropelAuth/terraform-provider-propelauth/issues/18).

Tested and verified expected behavior locally.