### PR TITLE
import for custom_domain_resource

### DIFF
--- a/docs/resources/custom_domain.md
+++ b/docs/resources/custom_domain.md
@@ -42,3 +42,14 @@ resource "propelauth_custom_domain" "my_custom_domain" {
 - `txt_record_key` (String) The TXT record key for the custom domain.
 - `txt_record_key_without_domain` (String) The TXT record key for the custom domain without the domain (e.g. just auth instead of auth.example.com) .
 - `txt_record_value` (String) The TXT record value for the custom domain.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Custom domains can be imported by which environment they are in
+terraform import propelauth_custom_domain.example Prod
+# or
+terraform import propelauth_custom_domain.example Staging
+```

--- a/docs/resources/custom_domain_verification.md
+++ b/docs/resources/custom_domain_verification.md
@@ -74,3 +74,14 @@ Optional:
 
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Custom domains can be imported by which environment they are in
+terraform import propelauth_custom_domain_verification.example Prod
+# or
+terraform import propelauth_custom_domain_verification.example Staging
+```

--- a/examples/resources/propelauth_custom_domain/import.sh
+++ b/examples/resources/propelauth_custom_domain/import.sh
@@ -1,0 +1,4 @@
+# Custom domains can be imported by which environment they are in
+terraform import propelauth_custom_domain.example Prod
+# or
+terraform import propelauth_custom_domain.example Staging

--- a/examples/resources/propelauth_custom_domain_verification/import.sh
+++ b/examples/resources/propelauth_custom_domain_verification/import.sh
@@ -1,0 +1,4 @@
+# Custom domains can be imported by which environment they are in
+terraform import propelauth_custom_domain_verification.example Prod
+# or
+terraform import propelauth_custom_domain_verification.example Staging

--- a/internal/provider/custom_domain_resource.go
+++ b/internal/provider/custom_domain_resource.go
@@ -310,5 +310,5 @@ func (r *customDomainResource) Delete(ctx context.Context, req resource.DeleteRe
 
 func (r *customDomainResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Retrieve import environment and save to environment attribute
-    resource.ImportStatePassthroughID(ctx, path.Root("environment"), req, resp)
+	resource.ImportStatePassthroughID(ctx, path.Root("environment"), req, resp)
 }


### PR DESCRIPTION
Depends on [this PR](https://github.com/PropelAuth/auth/pull/857)

## After PR
You can import `propelauth_custom_domain` resources by the environment (Prod | Staging).

## Tests
Verified you can import an the resource successfully.
